### PR TITLE
Update Simplified Chinese localization.

### DIFF
--- a/src/main/resources/assets/ironchest/lang/zh_cn.json
+++ b/src/main/resources/assets/ironchest/lang/zh_cn.json
@@ -22,5 +22,5 @@
   "item.ironchest.diamond_obsidian_upgrade": "升级：钻石→黑曜石",
   
   "_comment": "Item Groups",
-  "itemGroup.ironchest.ironchest": "铁箱子"
+  "itemGroup.ironchest.ironchest": "更多箱子"
 }


### PR DESCRIPTION
Update zh_cn.json
Note: I noticed "Extra Chests" changed to "Iron Chest". In Chinese Minecraft community, "Iron Chest" has been called as "Extra Chests" by players for many years, so I change "Iron Chest" in creative tab to "Extra Chest" again.