### PR TITLE
Remove unnecessary override

### DIFF
--- a/src/main/java/com/technovision/ironchest/blocks/blockentities/GenericIronChestBlockEntity.java
+++ b/src/main/java/com/technovision/ironchest/blocks/blockentities/GenericIronChestBlockEntity.java
@@ -34,11 +34,6 @@ public class GenericIronChestBlockEntity extends ChestBlockEntity implements Blo
     }
 
     @Override
-    public ScreenHandler createMenu(int syncId, PlayerInventory inventory, PlayerEntity player) {
-        return new ExtraChestScreenHandler(type.getScreenHandlerType(), type, syncId, inventory, ScreenHandlerContext.create(world, pos));
-    }
-
-    @Override
     protected ScreenHandler createScreenHandler(int syncId, PlayerInventory inventory) {
         return new ExtraChestScreenHandler(type.getScreenHandlerType(), type, syncId, inventory, ScreenHandlerContext.create(world, pos));
     }


### PR DESCRIPTION
Removed `GenericIronChestBlockEntity#createMenu` override. This is necessary as it calls createScreenHandler.
```java
    public ScreenHandler createMenu(int i, PlayerInventory playerInventory, PlayerEntity playerEntity) {
        return this.checkUnlocked(playerEntity) ? this.createScreenHandler(i, playerInventory) : null;
    }
```
Fixes compat with vanilla chest lock system and mods that use it.